### PR TITLE
Add '.' in function wordsCount documentation

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -714,7 +714,7 @@ class Str
     }
 
     /**
-     * Count word(s) number in a string
+     * Count word(s) number in a string.
      *
      * @param  string  $value
      * @return int


### PR DESCRIPTION
Fix typo